### PR TITLE
{AzureIoT} fixes Azure/azure-sdk-for-python#27252 update description  for create_device_with_sas method

### DIFF
--- a/src/azure/iot/hub/iothub_registry_manager.py
+++ b/src/azure/iot/hub/iothub_registry_manager.py
@@ -137,7 +137,7 @@ class IoTHubRegistryManager(object):
         device_scope=None,
         parent_scopes=None,
     ):
-        """Creates a device identity on IoTHub using SAS authentication.
+        """Creates a device identity on IoTHub that will use SAS as authentication method.
 
         :param str device_id: The name (Id) of the device.
         :param str primary_key: Primary authentication key.


### PR DESCRIPTION
fixes Azure/azure-sdk-for-python#27252

PR to update the description for create_device_with_sas method to "Creates a device identity on IoTHub that will use SAS as authentication method."